### PR TITLE
Fixed init date range configuration

### DIFF
--- a/src/js/rangedate-picker.js
+++ b/src/js/rangedate-picker.js
@@ -187,7 +187,7 @@ export default {
     }
   },
   created () {
-    this.range = this.initRange || null
+    this.dateRange = this.initRange || null
     if (this.isCompact) {
       this.isOpen = true
     }


### PR DESCRIPTION
There is small bug in code, instead of asigning initial date range to `this.dateRange` there was `this.range` in code