### PR TITLE
Update CDN link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Vue.use(VueRangedatePicker)
 <script src="vue-rangedate-picker/dist/vue-rangedate-picker.min.js"></script>
 
 <!-- From CDN -->
-<script src="https://unpkg.com/vue-rangedate-picker"></script>
+<script src="https://unpkg.com/vue-rangedate-picker/dist/vue-rangedate-picker.min.js"></script>
 ```
 
 ### Available Events


### PR DESCRIPTION
Updated based on a issue someone asked on [Stack Overflow](https://stackoverflow.com/questions/51030541/cant-use-3rd-party-components-with-vue-js-as-cdn/51034951#51034951)

CDN link needs to also specify `/dist/vue-rangedate-picker.min.js`.

Test

```html
<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.13/vue.min.js">
</script>
<script src="https://unpkg.com/vue-rangedate-picker/dist/vue-rangedate-picker.min.js">
</script>

<div id="app">
  <vue-rangedate-picker
    @selected="onDateSelected" i18n="EN" format="YYYY-MM-DD hh:mm:ss">
  </vue-rangedate-picker>
</div>
</body>

<script>
document.addEventListener("DOMContentLoaded", () => {
  VueRangedatePicker.default.install(Vue)

  new Vue({
    el: "#app",
    methods: {
      onDateSelected() {
      }
    }
  })
})
</script>
</html>
``` 

Removing `dist/vue-rangedate-picker.min.js` from the CDN causes it not to work.