### PR TITLE
fix start date of the new year in non-copact-mode

### DIFF
--- a/src/js/rangedate-picker.js
+++ b/src/js/rangedate-picker.js
@@ -212,7 +212,7 @@ export default {
       return new Date(this.activeYearStart, this.activeMonthStart, 1).getDay()
     },
     startNextMonthDay: function () {
-      return new Date(this.activeYearStart, this.startNextActiveMonth, 1).getDay()
+      return this.startNextActiveMonth === 0 ? new Date(this.activeYearStart, 12, 1).getDay() : new Date(this.activeYearStart, this.startNextActiveMonth, 1).getDay()
     },
     endMonthDate: function () {
       return new Date(this.activeYearEnd, this.startNextActiveMonth, 0).getDate()


### PR DESCRIPTION
Hi,

i fix the issue https://github.com/bliblidotcom/vue-rangedate-picker/issues/65
it starts correctly day of week which extend form one year to next.

please check and if it's good to you,please merge this commit