### PR TITLE
Fix isDateInRange

### DIFF
--- a/src/js/rangedate-picker.js
+++ b/src/js/rangedate-picker.js
@@ -321,7 +321,7 @@ export default {
     },
     isDateInRange (r, i, key, startMonthDay, endMonthDate) {
       const result = this.getDayIndexInMonth(r, i, startMonthDay)
-      if (result < 2 || result > endMonthDate) return false
+      if (result < 1 || result > endMonthDate) return false
 
       let currDate = null
       if (key === 'first') {


### PR DESCRIPTION
When the range is selected first day of next month doesn't get .calendar_days_in-range class

